### PR TITLE
Fix declaration file

### DIFF
--- a/simple-diff.d.ts
+++ b/simple-diff.d.ts
@@ -1,35 +1,37 @@
-declare function diff(oldObj: any, newObj: any, ops?: DiffOptions): DiffEvent[];
+declare function diff(oldObj: any, newObj: any, ops?: diff.DiffOptions): diff.DiffEvent[];
 
-export default diff;
+declare namespace diff {
+	export interface DiffOptions extends Partial<PathChange> {
+		idProp?: string,
+		idProps?: {[path: string]: string},
+		addEvent?: string,
+		removeEvent?: string,
+		changeEvent?: string,
+		addItemEvent?: string,
+		removeItemEvent?: string,
+		moveItemEvent?: string,
+		callback?: (event: DiffEvent) => void,
+		comparators?: Array<[any, Comparator]>,
+		ignore?: Comparator,
+	}
 
-export interface DiffOptions extends Partial<PathChange> {
-	idProp?: string,
-	idProps?: {[path: string]: string},
-	addEvent?: string,
-	removeEvent?: string,
-	changeEvent?: string,
-	addItemEvent?: string,
-	removeItemEvent?: string,
-	moveItemEvent?: string,
-	callback?: (event: DiffEvent) => void,
-	comparators?: Array<[any, Comparator]>,
-	ignore?: Comparator,
+	export type Path = Array<string | number>;
+
+	export interface PathChange {
+		oldPath: Path,
+		newPath: Path,
+	}
+
+	export type Comparator = (oldValue: any, newValue: any, options: PathChange) => boolean;
+
+	export interface DiffEvent extends PathChange {
+		type: 'add' | 'remove' | 'change' | 'add-item' | 'remove-item' | 'move-item',
+		oldValue: any,
+		newValue: any,
+		oldIndex?: number,
+		curIndex?: number,
+		newIndex?: number,
+	}
 }
 
-export type Path = Array<string | number>;
-
-export interface PathChange {
-	oldPath: Path,
-	newPath: Path,
-}
-
-export type Comparator = (oldValue: any, newValue: any, options: PathChange) => boolean;
-
-export interface DiffEvent extends PathChange {
-	type: 'add' | 'remove' | 'change' | 'add-item' | 'remove-item' | 'move-item',
-	oldValue: any,
-	newValue: any,
-	oldIndex?: number,
-	curIndex?: number,
-	newIndex?: number,
-}
+export = diff;


### PR DESCRIPTION
[Are the types wrong?](https://arethetypeswrong.github.io/?p=simple-diff%401.7.2) shows that the declaration file is incorrect. It should be using `export =` instead of `export default` since the underlying JavaScript is CJS.

This PR follows the docs for how to define default exports as described [here](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html#default-exports).

<img width="828" height="780" alt="image" src="https://github.com/user-attachments/assets/c7a57c93-fd13-43c6-b7fc-5a52eec912f3" />
